### PR TITLE
feat: add line placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ The command target will be the active editor if from the command palette, or sel
 -   `${files}` - Replaced with the targets file paths separated by space
 -   `${dir}` - Replaced with the first target directory path
 -   `${project}` - Replaced with the first target file's project path
+-   `${line}` - Replaced with the line number of the most recently added cursor. (_Only works_ when called from the command palette.)

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,4 +34,10 @@ export default {
 		type: "string",
 		default: "${project}"
 	},
+	"linePlaceholder": {
+		title: "Line Placeholder",
+		description: "Replace this string with the line number of the most recently added cursor in the active buffer.",
+		type: "string",
+		default: "${line}"
+	},
 };

--- a/lib/terminal-commands.js
+++ b/lib/terminal-commands.js
@@ -51,6 +51,10 @@ export default {
 			this.projectPlaceholder = new RegExp(this.escapeRegexp(value), "g");
 		}));
 
+		this.subscriptions.add(atom.config.observe("terminal-commands.linePlaceholder", (value) => {
+			this.linePlaceholder = new RegExp(this.escapeRegexp(value), "g");
+		}));
+
 	},
 
 	deactivate() {
@@ -225,6 +229,7 @@ export default {
 			const hasFiles = !!files[0];
 			const dir = (hasFiles ? path.dirname(files[0]) : null);
 			const [project] = (hasFiles ? atom.project.relativizePath(files[0]) : [null]);
+			const line = this.getLine();
 
 			const errors = {};
 
@@ -263,6 +268,13 @@ export default {
 						error(cmd, "No project found");
 					} else {
 						replacedCmd = replacedCmd.replace(this.projectPlaceholder, project);
+					}
+				}
+				if (this.linePlaceholder) {
+					if (!line && replacedCmd.match(this.linePlaceholder)) {
+						error(cmd, "Could not determine line number");
+					} else {
+						replacedCmd = replacedCmd.replace(this.linePlaceholder, line);
 					}
 				}
 				return replacedCmd;
@@ -330,6 +342,19 @@ export default {
 		}
 
 		return [];
+	},
+
+	/**
+	 * Get the line number of the most recently added cursor in the active buffer.
+	 * @return {int} line number or 0 if there is no active pane
+	 */
+	getLine() {
+		const editor = atom.workspace.getActivePaneItem();
+
+		return (editor && typeof editor.getCursorBufferPosition === "function")
+			// called from active pane
+			? editor.getCursorBufferPosition().row + 1
+			: 0;
 	},
 
 	consumeRunInTerminal(terminal) {

--- a/spec/terminal-commands-spec.js
+++ b/spec/terminal-commands-spec.js
@@ -312,7 +312,44 @@ describe("terminal-commands", function () {
 
 			await dispatch.promise;
 
-			expect(terminalCommands.terminals[0].run).toHaveBeenCalledWith(['test 123']);
+			expect(terminalCommands.terminals[0].run).toHaveBeenCalledWith(["test 123"]);
+		});
+	});
+	describe("when called with an active pane item", function () {
+		let currentFile;
+		const mockEvent = {
+			closest() {
+				return false;
+			}
+		};
+		beforeEach(async function () {
+			const loaded = promisificator();
+			terminalCommands.onLoaded(loaded.callback);
+
+			atom.config.set(
+				"terminal-commands.configFile",
+				await createConfig(configFolder, "terminal-commands.js", {})
+			);
+
+			// build the current file
+			currentFile = path.join(configFolder, "foo.js");
+			await promisify(fs.writeFile)(currentFile, "\n\nfoo\nbar");
+			// buffer position is 0 indexed, but "line number" is 1 indexed
+			const currentPosition = [2, 0];
+
+			// open the file and move cursor to line 3
+			await atom.workspace.open(currentFile);
+			atom.workspace.getActivePaneItem().setCursorBufferPosition(currentPosition);
+			await loaded.promise;
+		});
+		it("getLine should return the current line number", function () {
+			expect(terminalCommands.getLine()).toBe(3);
+		});
+		it("getPaths should return an array containing the currently open file", function () {
+			const paths = terminalCommands.getPaths(mockEvent);
+			expect(paths instanceof Array).toBeTrue();
+			expect(paths.length).toBe(1);
+			expect(paths[0]).toBe(currentFile);
 		});
 	});
 	describe("terminal command objects", function () {

--- a/spec/terminal-commands-spec.js
+++ b/spec/terminal-commands-spec.js
@@ -230,6 +230,7 @@ describe("terminal-commands", function () {
 				"test:files": "test ${files}",
 				"test:dir": "test ${dir}",
 				"test:project": "test ${project}",
+				"test:line": "test ${line}",
 			}));
 
 			terminalCommands.consumeRunInTerminal({
@@ -244,6 +245,7 @@ describe("terminal-commands", function () {
 			];
 
 			spyOn(terminalCommands, "getPaths").and.returnValues(files);
+			spyOn(terminalCommands, "getLine").and.returnValue(123);
 
 			await loaded.promise;
 
@@ -304,6 +306,13 @@ describe("terminal-commands", function () {
 
 			expect(atom.notifications.addError).toHaveBeenCalled();
 			expect(terminalCommands.terminals[0].run).not.toHaveBeenCalled();
+		});
+		it("should replace linePlaceholder", async function () {
+			atom.commands.dispatch(atom.views.getView(atom.workspace), "test:line");
+
+			await dispatch.promise;
+
+			expect(terminalCommands.terminals[0].run).toHaveBeenCalledWith(['test 123']);
 		});
 	});
 	describe("terminal command objects", function () {

--- a/spec/terminal-commands-spec.js
+++ b/spec/terminal-commands-spec.js
@@ -335,15 +335,23 @@ describe("terminal-commands", function () {
 			currentFile = path.join(configFolder, "foo.js");
 			await promisify(fs.writeFile)(currentFile, "\n\nfoo\nbar");
 			// buffer position is 0 indexed, but "line number" is 1 indexed
-			const currentPosition = [2, 0];
+			const currentPosition = [1, 0];
 
-			// open the file and move cursor to line 3
+			// open the file and move cursor to line 2
 			await atom.workspace.open(currentFile);
 			atom.workspace.getActivePaneItem().setCursorBufferPosition(currentPosition);
 			await loaded.promise;
 		});
 		it("getLine should return the current line number", function () {
+			expect(terminalCommands.getLine()).toBe(2);
+		});
+		it("getLine should return the last cursor line number", function () {
+			atom.workspace.getActivePaneItem().addCursorAtBufferPosition([2, 1]);
 			expect(terminalCommands.getLine()).toBe(3);
+		});
+		it("getLine should return the last cursor line number", function () {
+			atom.workspace.getActivePaneItem().addCursorAtBufferPosition([0, 0]);
+			expect(terminalCommands.getLine()).toBe(1);
 		});
 		it("getPaths should return an array containing the currently open file", function () {
 			const paths = terminalCommands.getPaths(mockEvent);


### PR DESCRIPTION
Hi, thanks for this package. This PR adds a new `${line}` placeholder which will be replaced w/ the current line number of the cursor in the active editor. My use case is that I have a local script that will stage/unstage git hunks if given a file name and line number, and I wanted to be able to call that w/ this package. This is working as written, and includes a test for the new substitution. 

**Example:**
This feature will turn this `git stage-hunk-at-line "${file}" ${line}` into this `git stage-hunk-at-line "filename.txt" 123`. 

**Questions:**
1. I *think* I've written this correctly to error gracefully if called from w/i the tree view, but I never use that feature (didn't even know it existed until writing this!) so it should get a critical eye. (The error message is working w/i the editor, FWIW.)  I modeled this code off of the behavior of `getPaths()`.
2. This only supports a single cursor/line as that's all I need. I don't think it would be too difficult to alter it to act like the `files`/`file` placeholders so that a `lines` placeholder could return a space delimited list of lines for *all* cursors in the active editor, and `line` just returns the first of those. As I said, the current code scratches my itch, but I could update this if you'd prefer that symmetry.

Thanks again!